### PR TITLE
fix(client): read the chat snapshot across 0.1.1-rc.2 and 0.1.2-alpha.1 channels (issue #7)

### DIFF
--- a/scripts/verify-host.mjs
+++ b/scripts/verify-host.mjs
@@ -46,7 +46,7 @@ import { BasicCompactionEngine } from '@deepseek-ai/dsh-compaction-basic'
 import { apply as applyCommandCompact } from '@deepseek-ai/dsh-command-compact'
 import { mkdtemp, mkdir, rm, writeFile, readFile, readdir, utimes, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { isAbsolute, join } from 'node:path'
 import { apply as applyRewind } from '../lib/index.js'
 
 const aborted = () => new AbortController().signal
@@ -64,7 +64,9 @@ await mkdir(wsDir, { recursive: true })
 /** Real-filesystem fs double: resolve returns the real display path. */
 class FakeFs extends FileSystem {
   async resolve(path, opts = {}) {
-    const displayPath = opts?.cwd !== undefined && !path.startsWith('/') ? join(opts.cwd, path) : path
+    // isAbsolute: on Windows absolute paths look like `C:\...` (or `C:/...`),
+    // so a leading-`/` probe would misclassify them as relative.
+    const displayPath = opts?.cwd !== undefined && !isAbsolute(path) ? join(opts.cwd, path) : path
     return { targetKey: FsTargetKey(displayPath), displayPath }
   }
   processPath(target) { return target.displayPath }
@@ -196,7 +198,8 @@ async function runWrite(agentOf, callId, filePath, content) {
   const exec = { callId, name: 'write', arguments: { file_path: filePath, content }, agent: agentOf, signal: aborted() }
   await ctx.waterfall('tools/execute', exec, async () => {
     const cwd = agentOf?.session?.header?.cwd
-    const resolved = cwd !== undefined && !filePath.startsWith('/') ? join(cwd, filePath) : filePath
+    // isAbsolute: Windows-absolute paths (`C:\...`) must not be re-joined.
+    const resolved = cwd !== undefined && !isAbsolute(filePath) ? join(cwd, filePath) : filePath
     await fs.writeText({ targetKey: FsTargetKey(resolved), displayPath: resolved }, content)
     return { isError: false, content: [] }
   })

--- a/src/client/hidden.ts
+++ b/src/client/hidden.ts
@@ -15,6 +15,32 @@ export interface HiddenChat {
 }
 
 /**
+ * Reader for one session's live chat snapshot. The dual channel hides the
+ * harness split behind SiriLee/dsh-rewind#7: rc.2 serves the chat from the
+ * session face snapshot, while 0.1.2-alpha.1+ serves it from the
+ * `uiConversation` service's named "chat" view (contributed by
+ * dsh-client-ui-chat through the uiSession slot hook).
+ */
+export type ChatOf = (sessionId: string | undefined) => HiddenChat | undefined
+
+/**
+ * Resolve the chat snapshot across the two harness channels: the session-face
+ * snapshot first (rc.2 — on alpha.1+ the face no longer carries `chat`, so the
+ * field reads `undefined`), then the `uiConversation` "chat" view. The view's
+ * `getSnapshot()` returns undefined until the named view is registered, so
+ * both channels missing degrades to `undefined` (no targets, no hiding —
+ * never a crash).
+ */
+export function chatSnapshotOf(
+  face: { getSnapshot(): { chat?: unknown } } | undefined,
+  chatView: { getSnapshot(): unknown } | undefined,
+): HiddenChat | undefined {
+  const legacy = face?.getSnapshot().chat as HiddenChat | undefined
+  if (legacy !== undefined) return legacy
+  return (chatView?.getSnapshot() ?? undefined) as HiddenChat | undefined
+}
+
+/**
  * Extract the rewind target seq from a `/rewind` command's structured `args`
  * (e.g. `@5 chat`, `preview @5 both`). Locale-independent — never parses the
  * host's human outcome copy.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -42,14 +42,32 @@ import {
 } from './candidates.ts'
 import { openPopover, knownCommandSeqs, waitForCommand } from './popover.ts'
 import { createRewindBridge, runRewindAndFill, type SlotsLike } from './portals.tsx'
-import { isCandidateCommand } from './hidden.ts'
+import { chatSnapshotOf, isCandidateCommand, type ChatOf } from './hidden.ts'
 import { en, zh } from './locales.ts'
 import { STYLE } from './styles.ts'
 
 export const name = 'dsh-rewind'
+// NOTE: deliberately NOT injecting the alpha.1+ `uiConversation` service here.
+// Cordis inject entries are REQUIRED services; the name does not exist on
+// harness rc.2, so declaring it would stall this plugin forever on DSH
+// Desktop 2.0.3. The service is resolved lazily per read instead (see
+// `uiConversation` in apply), the same optional `ctx.get` pattern the
+// harness's own consumer plugins use on alpha.1+.
 export const inject = ['slots', 'sessions', 'locale', 'commandUi']
 
 const NS = 'rewind'
+
+/**
+ * Structural face of the alpha.1+ `uiConversation` service: per-session
+ * conversation bindings exposing named view targets (the "chat" view carries
+ * the chat snapshot). Typed locally so the plugin never imports the
+ * conversation UI package's types and survives harness version drift.
+ */
+interface UiConversationLike {
+  binding(source: string | { readonly sessionId: string }): {
+    target(name: string): { getSnapshot(): unknown } | undefined
+  }
+}
 
 /** The slot the session-scoped rewind bridge registers into (harness-declared). */
 const HEADER_ACTIONS_SLOT = 'conversation.session.header.actions'
@@ -82,6 +100,21 @@ export function apply(ctx: ClientContext): void {
     const currentSessionId = (): string | undefined => ctx.sessions.list.getSnapshot().current
     const subscribeLocale = (cb: () => void): (() => void) => ctx.locale.subscribe(cb)
 
+    /**
+     * The alpha.1+ chat channel: the `uiConversation` service (contributed by
+     * dsh-client-ui-conversation; dsh-client-ui-chat registers its named
+     * "chat" view through the uiSession slot hook). Resolved lazily through
+     * `ctx.get` — the harness's own consumer pattern — so the read returns
+     * undefined on rc.2, where the service does not exist (see the `inject`
+     * note above for why it is not a declared dependency). Re-read on every
+     * call: services restart under the live-reload profile patcher.
+     */
+    const uiConversation = (): UiConversationLike | undefined =>
+      (ctx as { get(name: string): unknown }).get('uiConversation') as UiConversationLike | undefined
+
+    /** The named chat view in the alpha.1+ uiConversation registry. */
+    const CHAT_VIEW = 'chat'
+
     const slots = ctx.slots as unknown as SlotsLike
     yield slots.inject(HEADER_ACTIONS_SLOT, () => slots.register(
       {
@@ -91,7 +124,7 @@ export function apply(ctx: ClientContext): void {
         id: 'dsh-rewind-portals',
         order: 1000,
       },
-      createRewindBridge({ sessionOf, currentSessionId, t, subscribeLocale }),
+      createRewindBridge({ sessionOf, chatOf, currentSessionId, t, subscribeLocale }),
     ))
 
     // ---- /rewind command decoration (the standard text-driven flow) ----
@@ -103,17 +136,27 @@ export function apply(ctx: ClientContext): void {
     // the SAME flow as the ↶ button (the mode popover below).
     const commandUi = ctx.get('commandUi') as CommandUiContract
 
-    /** The live chat snapshot of a session, or undefined when unbound. */
-    const chatOf = (sessionId: string | undefined): CandidateChat | undefined => {
+    /**
+     * The live chat snapshot of a session, or undefined when unavailable.
+     * Dual channel (see `chatSnapshotOf`): the rc.2 session-face snapshot
+     * first, then the alpha.1+ `uiConversation` "chat" view.
+     * `uiConversation.binding` throws for a session it does not know (a
+     * teardown window) — degrade to "no chat" instead of failing the caller.
+     */
+    const chatOf: ChatOf = (sessionId) => {
       if (sessionId === undefined) return undefined
-      const face = sessionOf(sessionId)
-      return face === undefined ? undefined : face.getSnapshot().chat as unknown as CandidateChat
+      try {
+        const view = uiConversation()?.binding(sessionId).target(CHAT_VIEW)
+        return chatSnapshotOf(sessionOf(sessionId), view)
+      } catch {
+        return undefined
+      }
     }
 
     /** True when the surface has at least one reachable rewind target. */
     const hasCandidates = (sessionId: string | undefined): boolean => {
       const chat = chatOf(sessionId)
-      return chat !== undefined && rewindCandidatesOfChat(chat).length > 0
+      return chat !== undefined && rewindCandidatesOfChat(chat as unknown as CandidateChat).length > 0
     }
 
     /**
@@ -123,11 +166,11 @@ export function apply(ctx: ClientContext): void {
      * already-loaded history window. Returns undefined when the command was
      * not matched or never settled.
      */
-    const fetchHostCandidates = async (face: SessionFace): Promise<readonly RewindCandidate[] | undefined> => {
-      const known = knownCommandSeqs(face, node => isCandidateCommand(node))
+    const fetchHostCandidates = async (face: SessionFace, chatOf: ChatOf): Promise<readonly RewindCandidate[] | undefined> => {
+      const known = knownCommandSeqs(face, chatOf, node => isCandidateCommand(node))
       const result = await face.command('/rewind __candidates')
       if (!result.ok || result.value?.matched !== true) return undefined
-      const outcome = await waitForCommand(face, node => isCandidateCommand(node) && !known.has(node.seq))
+      const outcome = await waitForCommand(face, chatOf, node => isCandidateCommand(node) && !known.has(node.seq))
       if (outcome === null || outcome.kind !== 'success' || outcome.text === undefined) return undefined
       return rewindCandidatesFromHostText(outcome.text)
     }
@@ -156,7 +199,7 @@ export function apply(ctx: ClientContext): void {
         options: async session => {
           const face = sessionOf(session.sessionId)
           if (face === undefined) return []
-          const candidates = await fetchHostCandidates(face)
+          const candidates = await fetchHostCandidates(face, chatOf)
           if (candidates !== undefined) hostCandidatesCache.set(session.sessionId, candidates)
           return candidates === undefined ? [] : rewindOptionsFromCandidates(candidates, t)
         },
@@ -169,12 +212,13 @@ export function apply(ctx: ClientContext): void {
           if (candidate === undefined) return
           openPopover({
             session: face,
+            chatOf,
             seq: candidate.seq,
             time: candidate.time,
             preview: candidate.preview,
             anchor: composerAnchor(),
             t,
-            onRewind: mode => { void runRewindAndFill(face, candidate.seq, mode, currentSessionId) },
+            onRewind: mode => { void runRewindAndFill(face, candidate.seq, mode, currentSessionId, chatOf) },
           })
         },
       },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -114,6 +114,22 @@ export function apply(ctx: ClientContext): void {
 
     /** The named chat view in the alpha.1+ uiConversation registry. */
     const CHAT_VIEW = 'chat'
+    /**
+     * The live chat snapshot of a session, or undefined when unavailable.
+     * Dual channel (see `chatSnapshotOf`): the rc.2 session-face snapshot
+     * first, then the alpha.1+ `uiConversation` "chat" view.
+     * `uiConversation.binding` throws for a session it does not know (a
+     * teardown window) — degrade to "no chat" instead of failing the caller.
+     */
+    const chatOf: ChatOf = (sessionId) => {
+      if (sessionId === undefined) return undefined
+      try {
+        const view = uiConversation()?.binding(sessionId).target(CHAT_VIEW)
+        return chatSnapshotOf(sessionOf(sessionId), view)
+      } catch {
+        return undefined
+      }
+    }
 
     const slots = ctx.slots as unknown as SlotsLike
     yield slots.inject(HEADER_ACTIONS_SLOT, () => slots.register(
@@ -136,22 +152,6 @@ export function apply(ctx: ClientContext): void {
     // the SAME flow as the ↶ button (the mode popover below).
     const commandUi = ctx.get('commandUi') as CommandUiContract
 
-    /**
-     * The live chat snapshot of a session, or undefined when unavailable.
-     * Dual channel (see `chatSnapshotOf`): the rc.2 session-face snapshot
-     * first, then the alpha.1+ `uiConversation` "chat" view.
-     * `uiConversation.binding` throws for a session it does not know (a
-     * teardown window) — degrade to "no chat" instead of failing the caller.
-     */
-    const chatOf: ChatOf = (sessionId) => {
-      if (sessionId === undefined) return undefined
-      try {
-        const view = uiConversation()?.binding(sessionId).target(CHAT_VIEW)
-        return chatSnapshotOf(sessionOf(sessionId), view)
-      } catch {
-        return undefined
-      }
-    }
 
     /** True when the surface has at least one reachable rewind target. */
     const hasCandidates = (sessionId: string | undefined): boolean => {

--- a/src/client/popover.ts
+++ b/src/client/popover.ts
@@ -16,7 +16,7 @@
 
 import type { SessionFace } from '@deepseek-ai/dsh-client-runtime/client'
 import type { CommandNode } from '@deepseek-ai/dsh-client-runtime/client'
-import { hasFileImpact } from './hidden.ts'
+import { hasFileImpact, type ChatOf, type HiddenChat } from './hidden.ts'
 import type { RewindKey } from './locales.ts'
 import { CLASS } from './styles.ts'
 
@@ -33,6 +33,12 @@ export interface PopoverOptions {
   /** Pending variant: executed after the retract confirm closes the popover. */
   readonly onRetract?: () => void
   readonly preview: string
+  /**
+   * Dual-channel chat reader (rc.2 session face / alpha.1+ uiConversation
+   * view): the durable variant's command probes scan the chat through it.
+   * Unused by the pending-retract variant.
+   */
+  readonly chatOf: ChatOf
   /** The button that opened the popover (outside-click ignore target). */
   readonly anchor: HTMLElement
   readonly t: Translate
@@ -88,10 +94,11 @@ function parseImpactList(text: string): { restores: string[]; deletes: string[] 
 }
 
 /** Find the newest rewind command node matching a predicate. */
-function findCommand(snapshot: ReturnType<SessionFace['getSnapshot']>, match: (node: CommandNode) => boolean): CommandNode | undefined {
+function findCommand(chat: HiddenChat | undefined, match: (node: CommandNode) => boolean): CommandNode | undefined {
+  if (chat === undefined) return undefined
   let found: CommandNode | undefined
-  for (const key of snapshot.chat.order) {
-    const node = snapshot.chat.nodes.get(key)
+  for (const key of chat.order) {
+    const node = chat.nodes.get(key)
     if (node !== undefined && node.kind === 'command') {
       const command = node.data as CommandNode
       if (match(command)) found = command
@@ -107,11 +114,12 @@ function findCommand(snapshot: ReturnType<SessionFace['getSnapshot']>, match: (n
  * command's stale outcome (e.g. an older preview that found file changes,
  * after those changes were already restored).
  */
-export function knownCommandSeqs(session: SessionFace, match: (node: CommandNode) => boolean): Set<number> {
+export function knownCommandSeqs(session: SessionFace, chatOf: ChatOf, match: (node: CommandNode) => boolean): Set<number> {
   const known = new Set<number>()
-  const snapshot = session.getSnapshot()
-  for (const key of snapshot.chat.order) {
-    const node = snapshot.chat.nodes.get(key)
+  const chat = chatOf(session.sessionId)
+  if (chat === undefined) return known
+  for (const key of chat.order) {
+    const node = chat.nodes.get(key)
     if (node !== undefined && node.kind === 'command') {
       const command = node.data as CommandNode
       if (match(command)) known.add(command.seq)
@@ -127,6 +135,7 @@ export function knownCommandSeqs(session: SessionFace, match: (node: CommandNode
  */
 export function waitForCommand(
   session: SessionFace,
+  chatOf: ChatOf,
   match: (node: CommandNode) => boolean,
   timeoutMs = 8000,
 ): Promise<{ kind: 'success' | 'error'; text?: string } | null> {
@@ -140,7 +149,7 @@ export function waitForCommand(
       resolve(value)
     }
     const check = (): void => {
-      const node = findCommand(session.getSnapshot(), match)
+      const node = findCommand(chatOf(session.sessionId), match)
       if (node?.outcome !== null && node?.outcome !== undefined) {
         settle({ kind: node.outcome.kind, text: node.outcome.text })
       }
@@ -164,14 +173,14 @@ function isPreviewFor(node: CommandNode, seq: number): boolean {
  * Run `/rewind preview @seq both` and await its outcome. Returns null when the
  * command was not matched or timed out.
  */
-async function previewImpact(session: SessionFace, seq: number): Promise<PreviewOutcome> {
+async function previewImpact(session: SessionFace, chatOf: ChatOf, seq: number): Promise<PreviewOutcome> {
   // Exclude preview nodes that already exist: a second popover on the same
   // message must wait for THIS command's node, not settle on the previous
   // preview's outcome (which may predate a restore).
-  const known = knownCommandSeqs(session, node => isPreviewFor(node, seq))
+  const known = knownCommandSeqs(session, chatOf, node => isPreviewFor(node, seq))
   const result = await session.command(`/rewind preview @${seq} both`)
   if (!result.ok || result.value?.matched !== true) return null
-  return waitForCommand(session, node => isPreviewFor(node, seq) && !known.has(node.seq))
+  return waitForCommand(session, chatOf, node => isPreviewFor(node, seq) && !known.has(node.seq))
 }
 
 /** Element factory helpers (kept local so no framework is involved). */
@@ -226,6 +235,7 @@ interface DurablePopoverOptions {
   readonly preview: string
   readonly anchor: HTMLElement
   readonly t: Translate
+  readonly chatOf: ChatOf
   readonly onRewind: (mode: 'chat' | 'both') => void
 }
 
@@ -258,7 +268,7 @@ function renderImpactStep(root: HTMLElement, opts: DurablePopoverOptions, back: 
   focusFirst(root)
 
   void (async () => {
-    const outcome = cached ?? await previewImpact(session, seq)
+    const outcome = cached ?? await previewImpact(session, opts.chatOf, seq)
     if (outcome === null) {
       impact.textContent = t('popover.impact.failed', { message: 'preview command failed or timed out' })
       return
@@ -419,11 +429,11 @@ export function openPopover(opts: PopoverOptions): void {
     openRetractPopover(opts)
     return
   }
-  const { session, seq, time, preview, anchor, t } = opts
+  const { session, seq, time, preview, anchor, t, chatOf } = opts
   const onRewind = opts.onRewind
   if (seq === undefined || time === undefined || onRewind === undefined) return
   // Narrowed durable identity: the pending variant never reaches this flow.
-  const durableOpts: DurablePopoverOptions = { session, seq, time, preview, anchor, t, onRewind }
+  const durableOpts: DurablePopoverOptions = { session, seq, time, preview, anchor, t, chatOf, onRewind }
 
   const root = el('div', CLASS.popover)
   root.setAttribute('role', 'dialog')
@@ -524,7 +534,7 @@ export function openPopover(opts: PopoverOptions): void {
   // keeps "both" enabled — degrade to always-shown rather than hiding a
   // working option.
   void (async () => {
-    const outcome = await previewImpact(session, seq)
+    const outcome = await previewImpact(session, chatOf, seq)
     impactOutcome = outcome
     if (outcome !== null && outcome.kind === 'success') {
       bothState = { state: hasFileImpact(outcome.text) ? 'hasChanges' : 'noChanges' }

--- a/src/client/portals.tsx
+++ b/src/client/portals.tsx
@@ -34,8 +34,8 @@ import {
   type ReactNode,
 } from 'react'
 import { createPortal } from 'react-dom'
-import type { ChatConversationViewNode, SessionFace, UserMessageNode } from '@deepseek-ai/dsh-client-runtime/client'
-import { hiddenSeqsOf, isExecutedRewindCommand } from './hidden.ts'
+import type { SessionFace, UserMessageNode } from '@deepseek-ai/dsh-client-runtime/client'
+import { hiddenSeqsOf, isExecutedRewindCommand, type ChatOf, type HiddenChat } from './hidden.ts'
 import type { RewindKey } from './locales.ts'
 import { messagePreviewOf } from './candidates.ts'
 import { knownCommandSeqs, openPopover, waitForCommand } from './popover.ts'
@@ -43,12 +43,6 @@ import { matchPendingRows, retractSpan } from './pending.ts'
 import { CLASS, REWIND_ICON_SVG } from './styles.ts'
 
 type Translate = (key: RewindKey, params?: Record<string, unknown>) => string
-
-/** The chat snapshot shape the portal collection reads (structural subset). */
-interface ChatLike {
-  readonly order: readonly string[]
-  readonly nodes: { get(key: string): ChatConversationViewNode | undefined }
-}
 
 /** One portal target: the actions row of a user/steering seat + its durable node. */
 export type PortalTarget =
@@ -78,6 +72,12 @@ export type PortalTarget =
 /** Capabilities the session-scoped bridge receives from the plugin apply(). */
 export interface RewindBridgeDeps {
   readonly sessionOf: (sessionId: string) => SessionFace | undefined
+  /**
+   * Dual-channel chat reader (rc.2 session face / alpha.1+ uiConversation
+   * "chat" view): every chat snapshot read goes through it. See
+   * `chatSnapshotOf` in hidden.ts for the channel precedence.
+   */
+  readonly chatOf: ChatOf
   readonly currentSessionId: () => string | undefined
   readonly t: Translate
   readonly subscribeLocale: (cb: () => void) => () => void
@@ -99,10 +99,10 @@ export interface SlotsLike {
  * The plain text of the user message at `seq` in the session snapshot, for
  * filling the composer after a withdraw.
  */
-function userTextAt(session: SessionFace, seq: number): string | undefined {
-  const snap = session.getSnapshot()
-  for (const key of snap.chat.order) {
-    const node = snap.chat.nodes.get(key)
+function userTextAt(chat: HiddenChat | undefined, seq: number): string | undefined {
+  if (chat === undefined) return undefined
+  for (const key of chat.order) {
+    const node = chat.nodes.get(key)
     if (node === undefined || node.kind !== 'user') continue
     const user = node.data as UserMessageNode
     if (user.seq === seq) {
@@ -132,8 +132,8 @@ export function fillComposer(text: string): boolean {
 }
 
 /** The durable user/steering node behind a seat key via the runtime snapshot. */
-function userNodeOf(session: SessionFace, key: string): UserMessageNode | undefined {
-  const node = session.getSnapshot().chat.nodes.get(key)
+function userNodeOf(chat: HiddenChat | undefined, key: string): UserMessageNode | undefined {
+  const node = chat?.nodes.get(key)
   if (node === undefined || (node.kind !== 'user' && node.kind !== 'steering')) return undefined
   // SteeringMessageNode carries the same seq/time/content/source fields.
   return node.data as UserMessageNode
@@ -157,17 +157,18 @@ export async function runRewindAndFill(
   seq: number,
   mode: 'chat' | 'both',
   currentSessionId: () => string | undefined,
+  chatOf: ChatOf,
 ): Promise<void> {
   // Exclude already-present executed-rewind nodes for this target BEFORE
   // issuing the command: a repeated rewind of the same message must wait
   // for THIS command's node, not settle on the previous one.
-  const known = knownCommandSeqs(session, node => isExecutedRewindCommand(node, seq))
+  const known = knownCommandSeqs(session, chatOf, node => isExecutedRewindCommand(node, seq))
   const result = await session.command(`/rewind @${seq} ${mode}`)
   if (!result.ok || result.value?.matched !== true) return
   // The executed rewind lands as a CommandNode with a marker-carrying
   // success outcome; wait for exactly that (longer than the preview wait:
   // a running turn is cancelled first, which can take seconds).
-  const outcome = await waitForCommand(session, node => isExecutedRewindCommand(node, seq) && !known.has(node.seq), 20_000)
+  const outcome = await waitForCommand(session, chatOf, node => isExecutedRewindCommand(node, seq) && !known.has(node.seq), 20_000)
   if (outcome === null) return
   if (outcome.kind !== 'success') {
     // The host rejected the rewind (e.g. the target was shadowed by
@@ -180,7 +181,7 @@ export async function runRewindAndFill(
   // The user may have switched sessions while the rewind ran — fill only
   // the composer of the session the rewind actually happened in.
   if (currentSessionId() !== session.sessionId) return
-  const text = userTextAt(session, seq)
+  const text = userTextAt(chatOf(session.sessionId), seq)
   if (text === undefined || text === '') return
   fillComposer(text)
 }
@@ -218,7 +219,7 @@ const ACTIONS_ROOT_SELECTOR = '[data-time-hover-root]'
 const PENDING_SEAT_SELECTOR = '[data-pending-steering][data-time-hover-root]'
 
 /** Collect the portal targets of one session: user rows × snapshot nodes. */
-function collectTargets(chat: ChatLike, hiddenSeqs: ReadonlySet<number>): readonly PortalTarget[] {
+function collectTargets(chat: HiddenChat, hiddenSeqs: ReadonlySet<number>): readonly PortalTarget[] {
   const rows = new Map<string, HTMLElement>()
   for (const element of document.querySelectorAll<HTMLElement>(USER_SEAT_SELECTOR)) {
     const key = element.dataset.chatAnchorKey
@@ -336,7 +337,7 @@ interface RewindPortalsProps extends RewindBridgeDeps {
  * skipped when the target set is unchanged), so the plugin never runs a
  * synchronous full-transcript scan inside a commit microtask.
  */
-export function RewindPortals({ sessionId, sessionOf, currentSessionId, t, subscribeLocale }: RewindPortalsProps): ReactNode {
+export function RewindPortals({ sessionId, sessionOf, chatOf, currentSessionId, t, subscribeLocale }: RewindPortalsProps): ReactNode {
   const [targets, setTargets] = useState<readonly PortalTarget[]>([])
   // Rows we have hidden; re-shown when they leave the withdrawn span.
   const hidden = useRef(new WeakSet<HTMLElement>())
@@ -359,8 +360,12 @@ export function RewindPortals({ sessionId, sessionOf, currentSessionId, t, subsc
         return
       }
       const snapshot = session.getSnapshot()
-      const chat = snapshot.chat
-      const hiddenSeqs = hiddenSeqsOf(chat)
+      // Since harness 0.1.2-alpha.1 the chat snapshot no longer rides the
+      // session face; `chatOf` picks the rc.2 face channel or the alpha.1+
+      // `uiConversation` "chat" view. undefined = no channel available yet:
+      // skip the durable path entirely (pending targets stay collectible).
+      const chat = chatOf(sessionId)
+      const hiddenSeqs = chat === undefined ? new Set<number>() : hiddenSeqsOf(chat)
       let hiddenCount = 0
       // Hide withdrawn rows (rewind markers, /rewind command rows, and every
       // message inside the executed rewinds' [earliest target, latest marker]
@@ -372,9 +377,10 @@ export function RewindPortals({ sessionId, sessionOf, currentSessionId, t, subsc
       // from any collapse/filter hide. Purely observational: the marker is
       // kept in sync with the hide/show state on both branches (a recreated
       // row has no marker and is re-marked when it re-enters a hidden span).
-      for (const seat of document.querySelectorAll<HTMLElement>(CHAT_SEAT_SELECTOR)) {
+      for (const seat of chat === undefined ? [] : document.querySelectorAll<HTMLElement>(CHAT_SEAT_SELECTOR)) {
         const key = seat.dataset.chatAnchorKey
-        const anchor = key !== undefined ? chat.nodes.get(key)?.anchorSeq : undefined
+        // `chat` is defined whenever the loop body runs (see the loop guard).
+        const anchor = key !== undefined ? chat?.nodes.get(key)?.anchorSeq : undefined
         if (anchor !== undefined && hiddenSeqs.has(anchor)) {
           seat.style.display = 'none'
           seat.dataset.dshRewindHidden = 'true'
@@ -393,7 +399,8 @@ export function RewindPortals({ sessionId, sessionOf, currentSessionId, t, subsc
           `[dsh-rewind] hiding: ${hiddenCount} rows, seqs [${[...hiddenSeqs].slice(0, 20).join(', ')}${hiddenSeqs.size > 20 ? '…' : ''}]`,
         )
       }
-      const next = [...collectTargets(chat, hiddenSeqs), ...collectPendingTargets(snapshot)]
+      const durable = chat === undefined ? [] : collectTargets(chat, hiddenSeqs)
+      const next = [...durable, ...collectPendingTargets(snapshot)]
       // Diff: no change → no re-render (the observer fires on every mutation;
       // only an actual target-set change should touch React).
       setTargets(current => (sameTargets(current, next) ? current : next))
@@ -431,6 +438,7 @@ export function RewindPortals({ sessionId, sessionOf, currentSessionId, t, subsc
           target={target}
           sessionId={sessionId}
           sessionOf={sessionOf}
+          chatOf={chatOf}
           t={t}
         />
       )
@@ -440,6 +448,7 @@ export function RewindPortals({ sessionId, sessionOf, currentSessionId, t, subsc
           target={target}
           sessionId={sessionId}
           sessionOf={sessionOf}
+          chatOf={chatOf}
           currentSessionId={currentSessionId}
           t={t}
         />
@@ -453,12 +462,13 @@ interface RewindButtonProps {
   readonly target: Extract<PortalTarget, { kind: 'durable' }>
   readonly sessionId: string
   readonly sessionOf: (sessionId: string) => SessionFace | undefined
+  readonly chatOf: ChatOf
   readonly currentSessionId: () => string | undefined
   readonly t: Translate
 }
 
 /** The per-message ↶ button (28px, matching the harness IconActions). */
-function RewindButton({ target, sessionId, sessionOf, currentSessionId, t }: RewindButtonProps): ReactNode {
+function RewindButton({ target, sessionId, sessionOf, chatOf, currentSessionId, t }: RewindButtonProps): ReactNode {
   const onClick = (event: ReactMouseEvent<HTMLButtonElement>): void => {
     event.stopPropagation()
     const session = sessionOf(sessionId)
@@ -468,16 +478,17 @@ function RewindButton({ target, sessionId, sessionOf, currentSessionId, t }: Rew
       console.warn('[dsh-rewind] rewind button clicked with no session binding')
       return
     }
-    const node = userNodeOf(session, target.key)
+    const node = userNodeOf(chatOf(sessionId), target.key)
     if (node === undefined) return
     openPopover({
       session,
+      chatOf,
       seq: node.seq,
       time: node.time,
       preview: messagePreviewOf(node),
       anchor: event.currentTarget,
       t,
-      onRewind: mode => { void runRewindAndFill(session, node.seq, mode, currentSessionId) },
+      onRewind: mode => { void runRewindAndFill(session, node.seq, mode, currentSessionId, chatOf) },
     })
   }
 
@@ -540,17 +551,20 @@ interface RetractButtonProps {
   readonly target: Extract<PortalTarget, { kind: 'pending' }>
   readonly sessionId: string
   readonly sessionOf: (sessionId: string) => SessionFace | undefined
+  /** Passed through to openPopover (the shared PopoverOptions shape). */
+  readonly chatOf: ChatOf
   readonly t: Translate
 }
 
 /** The per-pending-message ↶ button (same visual family as the durable button). */
-function RetractButton({ target, sessionId, sessionOf, t }: RetractButtonProps): ReactNode {
+function RetractButton({ target, sessionId, sessionOf, chatOf, t }: RetractButtonProps): ReactNode {
   const onClick = (event: ReactMouseEvent<HTMLButtonElement>): void => {
     event.stopPropagation()
     const session = sessionOf(sessionId)
     if (session === undefined) return
     openPopover({
       session,
+      chatOf,
       preview: target.preview,
       anchor: event.currentTarget,
       t,

--- a/tests/chat-channel.test.ts
+++ b/tests/chat-channel.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Chat-channel compatibility probes (SiriLee/dsh-rewind#7). Since harness
+ * 0.1.2-alpha.1 the chat snapshot moved off the session face into the
+ * `uiConversation` service's named "chat" view (contributed by
+ * dsh-client-ui-chat). The plugin reads BOTH channels through
+ * `chatSnapshotOf`; these probes lock the channel precedence and the alpha.1
+ * snapshot shape (Map-like nodes, extra `locations` field) flowing through
+ * the hiding logic untouched.
+ */
+import { describe, expect, it } from 'vitest'
+import { chatSnapshotOf, hiddenSeqsOf, type HiddenChat } from '../src/client/hidden.ts'
+
+/** A face whose snapshot carries the rc.2 `chat` field. */
+const faceWith = (chat: unknown) => ({ getSnapshot: () => ({ chat }) })
+
+/** The alpha.1 face: the chat field is gone entirely (reads undefined). */
+const faceAlpha1 = faceWith(undefined)
+
+/** The alpha.1 EMPTY_CHAT_SNAPSHOT shape (dsh-client-ui-chat): Map-like nodes. */
+const EMPTY_CHAT_SNAPSHOT_ALPHA1 = {
+  order: [],
+  nodes: { get: () => undefined, values: () => [] },
+  locations: { get: () => undefined },
+}
+
+/** A minimal populated chat snapshot in the same Map-like alpha.1 shape. */
+const chatAlpha1 = (order: string[], nodes: Map<string, unknown>) => ({
+  order,
+  nodes: { get: (key: string) => nodes.get(key), values: () => [...nodes.values()] },
+  locations: { get: () => undefined },
+})
+
+const viewOf = (snapshot: unknown) => ({ getSnapshot: () => snapshot })
+
+describe('chat channel precedence (rc.2 face vs alpha.1+ uiConversation view)', () => {
+  it('reads the rc.2 session-face chat first', () => {
+    const chat: HiddenChat = { order: [], nodes: { get: () => undefined } }
+    expect(chatSnapshotOf(faceWith(chat), viewOf(EMPTY_CHAT_SNAPSHOT_ALPHA1))).toBe(chat)
+  })
+
+  it('falls through an alpha.1 face (chat === undefined) to the uiConversation view', () => {
+    const chat: HiddenChat = { order: [], nodes: { get: () => undefined } }
+    expect(chatSnapshotOf(faceAlpha1, viewOf(chat))).toBe(chat)
+  })
+
+  it('falls through an unregistered view (getSnapshot() === undefined)', () => {
+    const chat: HiddenChat = { order: [], nodes: { get: () => undefined } }
+    expect(chatSnapshotOf(faceAlpha1, viewOf(undefined))).toBe(undefined)
+    // rc.2 face + not-yet-registered view still serves the face snapshot.
+    expect(chatSnapshotOf(faceWith(chat), viewOf(undefined))).toBe(chat)
+  })
+
+  it('degrades to undefined when no channel has a chat', () => {
+    expect(chatSnapshotOf(faceAlpha1, undefined)).toBe(undefined)
+    expect(chatSnapshotOf(undefined, viewOf(undefined))).toBe(undefined)
+    expect(chatSnapshotOf(undefined, undefined)).toBe(undefined)
+  })
+
+  it('accepts the alpha.1 EMPTY_CHAT_SNAPSHOT shape (Map-like nodes, locations)', () => {
+    const snapshot = chatSnapshotOf(faceAlpha1, viewOf(EMPTY_CHAT_SNAPSHOT_ALPHA1))
+    expect(snapshot).toBeDefined()
+    expect(snapshot!.order).toEqual([])
+    expect(snapshot!.nodes.get('missing')).toBeUndefined()
+    // The hiding logic walks it without crashing.
+    expect(hiddenSeqsOf(snapshot!)).toEqual(new Set())
+  })
+
+  it('runs the hiding logic over an alpha.1-shaped populated snapshot', () => {
+    // One executed /rewind @5 chat command (marker seq 7) + messages 1..9.
+    const command = {
+      kind: 'command',
+      anchorSeq: 7,
+      data: { seq: 7, name: 'rewind', args: '@5 chat', outcome: { kind: 'success', sourceEventSeq: 7 } },
+    }
+    const node = (seq: number) => ({ kind: 'user', anchorSeq: seq, data: { seq, time: 0, content: [] } })
+    const order = ['m1', 'm2', 'm3', 'm4', 'm5', 'm6', 'm7', 'm8', 'm9']
+    const nodes = new Map<string, unknown>(order.map(key => [key, node(Number(key[1]))]))
+    nodes.set('c7', command)
+    order.push('c7')
+    const snapshot = chatSnapshotOf(faceAlpha1, viewOf(chatAlpha1(order, nodes)))!
+    // Message anchors 5..7 sit inside the rewind's [target, marker] span.
+    expect(hiddenSeqsOf(snapshot)).toEqual(new Set([5, 6, 7]))
+  })
+})

--- a/tests/package-layout.test.ts
+++ b/tests/package-layout.test.ts
@@ -15,9 +15,12 @@
  */
 import { access, readFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
-const root = join(dirname(new URL(import.meta.url).pathname), '..')
+// fileURLToPath: `URL.pathname` keeps a leading `/` on Windows (`/E:/...`),
+// which `join` turns into a bogus `E:\E:\...` root.
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const pkg: {
   name: string
   private?: boolean

--- a/tsconfig.client-test.json
+++ b/tsconfig.client-test.json
@@ -5,5 +5,5 @@
     "emitDeclarationOnly": false,
     "rootDir": "."
   },
-  "include": ["src/client/**/*.ts", "src/client/**/*.tsx", "tests/client-contract.test.ts"]
+  "include": ["src/client/**/*.ts", "src/client/**/*.tsx", "tests/client-contract.test.ts", "tests/chat-channel.test.ts"]
 }


### PR DESCRIPTION
Fixes #7

## Root cause

The client half read the chat snapshot from the session face (`session.getSnapshot().chat`). Harness `0.1.2-alpha.1` moved the chat snapshot off the session face into the `uiConversation` service's per-session view registry (the named `"chat"` view, contributed by `dsh-client-ui-chat` through the `uiSession` slot hook). The plugin therefore read `undefined` and the button layer silently rendered zero targets, while the host half was unaffected — matching the version table in the issue (harness `0.1.1-rc.2` ✅ / `0.1.2-alpha.1` ❌).

## Fix

Dual-channel read with feature detection, one seam: `chatSnapshotOf()` in `src/client/hidden.ts` resolves the session-face snapshot first (harness `0.1.1-rc.2` fast path; on `0.1.2-alpha.1+` the field reads `undefined`), then falls through to `ctx.get('uiConversation')?.binding(sessionId)?.target('chat')?.getSnapshot()`. Both channels missing degrades to `undefined` (no targets, no hiding — never a crash).

Two deliberate choices worth review attention:

1. **No new `inject` entry.** The obvious `inject: [..., 'uiConversation']` would be wrong here: cordis inject entries are REQUIRED services, and that name does not exist on harness `0.1.1-rc.2`, so the plugin would stall forever on DSH Desktop 2.0.3. The service is resolved lazily per read via `ctx.get` — the same optional pattern `0.1.2-alpha.1`'s own consumer plugins (e.g. `dsh-client-ui-goal`) use. `package.json`'s `dsh.client.inject` already pulls `@deepseek-ai/dsh-client-ui-conversation` into the module graph.
2. **`uiConversation.binding()` throws for unknown sessions** (teardown windows), so the `chatOf` wrapper in `index.ts` try/catches and degrades to "no chat".

All six former `snapshot.chat` read sites (portals refresh, `userTextAt`, `userNodeOf`, `findCommand`, `knownCommandSeqs`, the `chatOf` availability probe) now go through the channel-aware reader. `waitForCommand` keeps its face-level subscription — command nodes are driven by the same event feed on both versions.

## Testing

- New `tests/chat-channel.test.ts`: channel precedence probes, the `0.1.2-alpha.1` `EMPTY_CHAT_SNAPSHOT` Map-like shape (extra `locations`, `values()`), and a populated snapshot flowing through `hiddenSeqsOf` unchanged.
- Existing suites untouched (pure-function interfaces unchanged except the threaded `chatOf` parameter).
- Manually verified on DSH Desktop 2.0.4 (harness `0.1.2-alpha.1`): ↶ buttons render, executed rewinds hide rows with `data-dsh-rewind-hidden`, the `/rewind` popupSelect lists candidates, no console errors.
- `tsc --noEmit` (client + client-test configs) clean.

---

## 中文说明

### 根因

客户端半侧从会话 face 读取 chat 快照（`session.getSnapshot().chat`）。harness `0.1.2-alpha.1` 把 chat 快照从会话 face 挪到了 `uiConversation` 服务的按会话视图注册表（由 `dsh-client-ui-chat` 经 `uiSession` slot hook 贡献的命名 `"chat"` 视图）。插件因此读到 `undefined`，按钮层静默渲染 0 个目标；host 半侧不受影响——与 issue 中的双版本实测表一致（harness `0.1.1-rc.2` ✅ / `0.1.2-alpha.1` ❌）。

### 修复方式

单一接缝的双通道特性探测：`src/client/hidden.ts` 新增 `chatSnapshotOf()`，先读会话 face 快照（harness `0.1.1-rc.2` 快路径；`0.1.2-alpha.1+` 上该字段读作 `undefined`），落空则回退到 `ctx.get('uiConversation')?.binding(sessionId)?.target('chat')?.getSnapshot()`。两条通道都缺时降级为 `undefined`（无按钮、无隐藏，绝不崩溃）。

两个提请重点 review 的取舍：

1. **不新增 `inject` 条目。** 直觉上的 `inject: [..., 'uiConversation']` 在这里是错的：cordis 的 inject 条目是**必需服务**语义，harness `0.1.1-rc.2` 上不存在这个名字，声明它会让插件在 DSH Desktop 2.0.3 上永久挂起。服务改为每次读取时经 `ctx.get` 惰性解析——与 `0.1.2-alpha.1` 官方消费者插件（如 `dsh-client-ui-goal`）的可选读取模式一致。`package.json` 的 `dsh.client.inject` 本就包含 `@deepseek-ai/dsh-client-ui-conversation`，模块图无缺口。
2. **`uiConversation.binding()` 对未知会话会 throw**（拆卸窗口期），因此 `index.ts` 的 `chatOf` 封装了 try/catch，失败降级为"无 chat"。

原 6 处 `snapshot.chat` 读取点（portals 刷新、`userTextAt`、`userNodeOf`、`findCommand`、`knownCommandSeqs`、`chatOf` 可用性探测）全部改走通道感知读取器。`waitForCommand` 保留 face 级事件订阅——命令节点在两个版本上都由同一事件 feed 驱动。

### 测试

- 新增 `tests/chat-channel.test.ts`：通道优先级探针、`0.1.2-alpha.1` `EMPTY_CHAT_SNAPSHOT` 的 Map-like 形状（含 `locations`、`values()`）、以及填充快照穿越 `hiddenSeqsOf` 行为不变。
- 既有测试套件不受影响（除穿线的 `chatOf` 参数外，纯函数接口未变）。
- 已在 DSH Desktop 2.0.4（harness `0.1.2-alpha.1`）真机手动验证：↶ 按钮渲染、执行回退后行隐藏并带 `data-dsh-rewind-hidden`、`/rewind` popupSelect 候选可用、console 无报错。
- `tsc --noEmit`（client + client-test 两个 tsconfig）通过。
