### PR TITLE
fix(client): wait for the alpha chat-view update signal in waitForCommand

### DIFF
--- a/src/client/hidden.ts
+++ b/src/client/hidden.ts
@@ -26,6 +26,15 @@ export type ChatOf = (
 ) => HiddenChat | undefined
 
 /**
+ * Subscribe to one session's live chat-update signal, for waiting on a chat
+ * snapshot change without polling. Dual-channel, mirroring `chatOf`: the
+ * alpha.1+ `uiConversation` "chat" view when registered, else the session face
+ * (rc.2, whose snapshot still carries `chat`, so its own `subscribe` is the
+ * chat-update signal). `cb` fires whenever the chat snapshot invalidates.
+ */
+export type ChatWatch = (sessionId: string, cb: () => void) => () => void
+
+/**
  * Resolve the chat snapshot across the two harness channels: the session-face
  * snapshot first (rc.2 — on alpha.1+ the face no longer carries `chat`, so the
  * field reads `undefined`), then the `uiConversation` "chat" view. The view's

--- a/src/client/hidden.ts
+++ b/src/client/hidden.ts
@@ -35,6 +35,27 @@ export type ChatOf = (
 export type ChatWatch = (sessionId: string, cb: () => void) => () => void
 
 /**
+ * Choose the chat-update subscription for `waitForCommand`: prefer the
+ * `uiConversation` "chat" view's own `subscribe` when available (alpha.1+,
+ * where the chat-update signal lives), else the session face's `subscribe`
+ * (rc.2, whose snapshot still carries the chat, so its own subscribe is the
+ * chat-update signal). Extracted as a pure channel-selection step so the
+ * "view vs face" branch is unit-testable; the resolvers are injected by the
+ * caller (see `watchChat` in index.ts). Never throws.
+ */
+export function resolveChatWatch(
+  resolveView: (sessionId: string) => { subscribe?(cb: () => void): () => void } | undefined,
+  resolveFace: (sessionId: string) => { subscribe(cb: () => void): () => void } | undefined,
+  sessionId: string,
+  cb: () => void,
+): () => void {
+  const view = resolveView(sessionId)
+  if (view?.subscribe !== undefined) return view.subscribe(cb)
+  const face = resolveFace(sessionId)
+  return face?.subscribe(cb) ?? (() => {})
+}
+
+/**
  * Resolve the chat snapshot across the two harness channels: the session-face
  * snapshot first (rc.2 — on alpha.1+ the face no longer carries `chat`, so the
  * field reads `undefined`), then the `uiConversation` "chat" view. The view's

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -42,7 +42,7 @@ import {
 } from './candidates.ts'
 import { openPopover, knownCommandSeqs, waitForCommand } from './popover.ts'
 import { createRewindBridge, runRewindAndFill, writeComposer, type SlotsLike } from './portals.tsx'
-import { chatSnapshotOf, isCandidateCommand, type ChatOf } from './hidden.ts'
+import { chatSnapshotOf, isCandidateCommand, type ChatOf, type ChatWatch } from './hidden.ts'
 import { rewindLog } from './log.ts'
 import { BUILD_HASH, PLUGIN_VERSION } from './build-info.ts'
 import { en, zh } from './locales.ts'
@@ -81,7 +81,7 @@ const NS = 'rewind'
  */
 interface UiConversationLike {
   binding(source: string | { readonly sessionId: string }): {
-    target(name: string): { getSnapshot(): unknown } | undefined
+    target(name: string): { getSnapshot(): unknown; subscribe?(cb: () => void): () => void } | undefined
   }
 }
 
@@ -220,6 +220,26 @@ export function apply(ctx: ClientContext): void {
       }
     }
 
+    /**
+     * Subscribe to one session's live chat-update signal (the wait signal for
+     * `waitForCommand`). On alpha.1+ the chat lives in the `uiConversation`
+     * "chat" view and the session face's `subscribe` no longer fires on a chat
+     * update, so prefer that view's `subscribe`; when the view is unreachable
+     * (rc.2, or before the view registers) fall back to the session face's own
+     * `subscribe` — which is exactly the chat-update signal there (its snapshot
+     * still carries the chat). Never throws.
+     */
+    const watchChat: ChatWatch = (sessionId, cb) => {
+      try {
+        const view = uiConversation()?.binding(sessionId).target(CHAT_VIEW)
+        if (view?.subscribe !== undefined) return view.subscribe(cb)
+      } catch {
+        // fall through: the view could not be resolved, use the session face
+      }
+      const face = sessionOf(sessionId)
+      return face?.subscribe(cb) ?? (() => {})
+    }
+
     const slots = ctx.slots as unknown as SlotsLike
     yield slots.inject(HEADER_ACTIONS_SLOT, () => slots.register(
       {
@@ -229,7 +249,7 @@ export function apply(ctx: ClientContext): void {
         id: 'dsh-rewind-portals',
         order: 1000,
       },
-      createRewindBridge({ sessionOf, chatOf, currentSessionId, setComposerText, t, subscribeLocale }),
+      createRewindBridge({ sessionOf, chatOf, currentSessionId, watchChat, setComposerText, t, subscribeLocale }),
     ))
 
     // ---- snapshot-cleanup settings card (Settings > Plugins > Plugin config) ----
@@ -317,7 +337,7 @@ export function apply(ctx: ClientContext): void {
       const known = knownCommandSeqs(face, chatOf, node => isCandidateCommand(node))
       const result = await face.command('/rewind __candidates')
       if (!result.ok || result.value?.matched !== true) return undefined
-      const outcome = await waitForCommand(face, chatOf, node => isCandidateCommand(node) && !known.has(node.seq))
+      const outcome = await waitForCommand(face, chatOf, node => isCandidateCommand(node) && !known.has(node.seq), 8000, cb => watchChat(face.sessionId, cb))
       if (outcome === null || outcome.kind !== 'success' || outcome.text === undefined) return undefined
       return rewindCandidatesFromHostText(outcome.text)
     }
@@ -360,12 +380,13 @@ export function apply(ctx: ClientContext): void {
           openPopover({
             session: face,
             chatOf,
+            watchChat,
             seq: candidate.seq,
             time: candidate.time,
             preview: candidate.preview,
             anchor: composerAnchor(),
             t,
-            onRewind: mode => { void runRewindAndFill(face, candidate.seq, mode, currentSessionId, chatOf, setComposerText) },
+            onRewind: mode => { void runRewindAndFill(face, candidate.seq, mode, currentSessionId, chatOf, watchChat, setComposerText) },
           })
         },
       },

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -42,7 +42,7 @@ import {
 } from './candidates.ts'
 import { openPopover, knownCommandSeqs, waitForCommand } from './popover.ts'
 import { createRewindBridge, runRewindAndFill, writeComposer, type SlotsLike } from './portals.tsx'
-import { chatSnapshotOf, isCandidateCommand, type ChatOf, type ChatWatch } from './hidden.ts'
+import { chatSnapshotOf, resolveChatWatch, isCandidateCommand, type ChatOf, type ChatWatch } from './hidden.ts'
 import { rewindLog } from './log.ts'
 import { BUILD_HASH, PLUGIN_VERSION } from './build-info.ts'
 import { en, zh } from './locales.ts'
@@ -222,23 +222,23 @@ export function apply(ctx: ClientContext): void {
 
     /**
      * Subscribe to one session's live chat-update signal (the wait signal for
-     * `waitForCommand`). On alpha.1+ the chat lives in the `uiConversation`
-     * "chat" view and the session face's `subscribe` no longer fires on a chat
-     * update, so prefer that view's `subscribe`; when the view is unreachable
-     * (rc.2, or before the view registers) fall back to the session face's own
-     * `subscribe` — which is exactly the chat-update signal there (its snapshot
-     * still carries the chat). Never throws.
+     * `waitForCommand`). Channel selection mirrors the chat's residence (see
+     * `resolveChatWatch`): on alpha.1+ prefer the `uiConversation` "chat" view's
+     * `subscribe`; when that view is unreachable (rc.2, or before it registers)
+     * fall back to the session face's own `subscribe`. Never throws.
      */
-    const watchChat: ChatWatch = (sessionId, cb) => {
-      try {
-        const view = uiConversation()?.binding(sessionId).target(CHAT_VIEW)
-        if (view?.subscribe !== undefined) return view.subscribe(cb)
-      } catch {
-        // fall through: the view could not be resolved, use the session face
-      }
-      const face = sessionOf(sessionId)
-      return face?.subscribe(cb) ?? (() => {})
-    }
+    const watchChat: ChatWatch = (sessionId, cb) => resolveChatWatch(
+      id => {
+        try {
+          return uiConversation()?.binding(id).target(CHAT_VIEW)
+        } catch {
+          return undefined
+        }
+      },
+      id => sessionOf(id),
+      sessionId,
+      cb,
+    )
 
     const slots = ctx.slots as unknown as SlotsLike
     yield slots.inject(HEADER_ACTIONS_SLOT, () => slots.register(

--- a/src/client/popover.ts
+++ b/src/client/popover.ts
@@ -16,7 +16,7 @@
 
 import type { SessionFace } from '@deepseek-ai/dsh-client-runtime/client'
 import type { CommandNode } from '@deepseek-ai/dsh-client-runtime/client'
-import { hasFileImpact, type ChatOf, type HiddenChat } from './hidden.ts'
+import { hasFileImpact, type ChatOf, type ChatWatch, type HiddenChat } from './hidden.ts'
 import type { RewindKey } from './locales.ts'
 import { CLASS } from './styles.ts'
 
@@ -39,6 +39,13 @@ export interface PopoverOptions {
    * Unused by the pending-retract variant.
    */
   readonly chatOf: ChatOf
+  /**
+   * Subscribe to one session's live chat-update signal, so a probe waiting on
+   * a command's chat node can be woken when the chat snapshot changes (alpha.1+
+   * the session face no longer fires on a chat update). Passed straight through
+   * to `waitForCommand`.
+   */
+  readonly watchChat: ChatWatch
   /** The button that opened the popover (outside-click ignore target). */
   readonly anchor: HTMLElement
   readonly t: Translate
@@ -138,6 +145,7 @@ export function waitForCommand(
   chatOf: ChatOf,
   match: (node: CommandNode) => boolean,
   timeoutMs = 8000,
+  watch?: (cb: () => void) => () => void,
 ): Promise<{ kind: 'success' | 'error'; text?: string } | null> {
   return new Promise(resolve => {
     let settled = false
@@ -154,7 +162,12 @@ export function waitForCommand(
         settle({ kind: node.outcome.kind, text: node.outcome.text })
       }
     }
-    const unsubscribe = session.subscribe(check)
+    // The chat-update signal: on alpha.1+ the session face's `subscribe` no
+    // longer fires when the chat snapshot changes (the chat moved to the
+    // `uiConversation` view), so a waiting caller passes a watch bound to that
+    // view. Otherwise fall back to the session face's own `subscribe`, which on
+    // rc.2 IS the chat-update signal (its snapshot still carries the chat).
+    const unsubscribe = (watch ?? ((cb: () => void) => session.subscribe(cb)))(check)
     const timer = setTimeout(() => settle(null), timeoutMs)
     check()
   })
@@ -173,14 +186,19 @@ function isPreviewFor(node: CommandNode, seq: number): boolean {
  * Run `/rewind preview @seq both` and await its outcome. Returns null when the
  * command was not matched or timed out.
  */
-async function previewImpact(session: SessionFace, chatOf: ChatOf, seq: number): Promise<PreviewOutcome> {
+async function previewImpact(
+  session: SessionFace,
+  chatOf: ChatOf,
+  seq: number,
+  watch?: (cb: () => void) => () => void,
+): Promise<PreviewOutcome> {
   // Exclude preview nodes that already exist: a second popover on the same
   // message must wait for THIS command's node, not settle on the previous
   // preview's outcome (which may predate a restore).
   const known = knownCommandSeqs(session, chatOf, node => isPreviewFor(node, seq))
   const result = await session.command(`/rewind preview @${seq} both`)
   if (!result.ok || result.value?.matched !== true) return null
-  return waitForCommand(session, chatOf, node => isPreviewFor(node, seq) && !known.has(node.seq))
+  return waitForCommand(session, chatOf, node => isPreviewFor(node, seq) && !known.has(node.seq), 8000, watch)
 }
 
 /** Element factory helpers (kept local so no framework is involved). */
@@ -236,6 +254,7 @@ interface DurablePopoverOptions {
   readonly anchor: HTMLElement
   readonly t: Translate
   readonly chatOf: ChatOf
+  readonly watchChat: ChatWatch
   readonly onRewind: (mode: 'chat' | 'both') => void
 }
 
@@ -268,7 +287,7 @@ function renderImpactStep(root: HTMLElement, opts: DurablePopoverOptions, back: 
   focusFirst(root)
 
   void (async () => {
-    const outcome = cached ?? await previewImpact(session, opts.chatOf, seq)
+    const outcome = cached ?? await previewImpact(session, opts.chatOf, seq, cb => opts.watchChat(session.sessionId, cb))
     if (outcome === null) {
       impact.textContent = t('popover.impact.failed', { message: 'preview command failed or timed out' })
       return
@@ -433,7 +452,7 @@ export function openPopover(opts: PopoverOptions): void {
   const onRewind = opts.onRewind
   if (seq === undefined || time === undefined || onRewind === undefined) return
   // Narrowed durable identity: the pending variant never reaches this flow.
-  const durableOpts: DurablePopoverOptions = { session, seq, time, preview, anchor, t, chatOf, onRewind }
+  const durableOpts: DurablePopoverOptions = { session, seq, time, preview, anchor, t, chatOf, watchChat: opts.watchChat, onRewind }
 
   const root = el('div', CLASS.popover)
   root.setAttribute('role', 'dialog')
@@ -534,7 +553,7 @@ export function openPopover(opts: PopoverOptions): void {
   // keeps "both" enabled — degrade to always-shown rather than hiding a
   // working option.
   void (async () => {
-    const outcome = await previewImpact(session, chatOf, seq)
+    const outcome = await previewImpact(session, chatOf, seq, cb => opts.watchChat(session.sessionId, cb))
     impactOutcome = outcome
     if (outcome !== null && outcome.kind === 'success') {
       bothState = { state: hasFileImpact(outcome.text) ? 'hasChanges' : 'noChanges' }

--- a/src/client/portals.tsx
+++ b/src/client/portals.tsx
@@ -35,7 +35,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import type { SessionFace, UserMessageNode } from '@deepseek-ai/dsh-client-runtime/client'
-import { hiddenSeqsOf, isExecutedRewindCommand, messageTextAt, type ChatOf, type HiddenChat } from './hidden.ts'
+import { hiddenSeqsOf, isExecutedRewindCommand, messageTextAt, type ChatOf, type ChatWatch, type HiddenChat } from './hidden.ts'
 import type { RewindKey } from './locales.ts'
 import { messagePreviewOf } from './candidates.ts'
 import { knownCommandSeqs, openPopover, waitForCommand } from './popover.ts'
@@ -79,6 +79,13 @@ export interface RewindBridgeDeps {
    * `chatSnapshotOf` in hidden.ts for the channel precedence.
    */
   readonly chatOf: ChatOf
+  /**
+   * Subscribe to one session's live chat-update signal, so the composer refill
+   * waiting on an executed rewind's chat node can be woken when the chat
+   * snapshot changes (alpha.1+ the session face no longer fires on a chat
+   * update). Passed through to `waitForCommand`.
+   */
+  readonly watchChat: ChatWatch
   readonly currentSessionId: () => string | undefined
   readonly t: Translate
   readonly subscribeLocale: (cb: () => void) => () => void
@@ -228,6 +235,7 @@ export async function runRewindAndFill(
   mode: 'chat' | 'both',
   currentSessionId: () => string | undefined,
   chatOf: ChatOf,
+  watchChat: ChatWatch,
   setComposerText: (sessionId: string, text: string) => boolean,
 ): Promise<void> {
   // Exclude already-present executed-rewind nodes for this target BEFORE
@@ -251,7 +259,7 @@ export async function runRewindAndFill(
   // a running turn is cancelled first, which can take seconds).
   let outcome: Awaited<ReturnType<typeof waitForCommand>>
   try {
-    outcome = await waitForCommand(session, chatOf, node => isExecutedRewindCommand(node, seq) && !known.has(node.seq), 20_000)
+    outcome = await waitForCommand(session, chatOf, node => isExecutedRewindCommand(node, seq) && !known.has(node.seq), 20_000, cb => watchChat(session.sessionId, cb))
   } catch (error) {
     rewindLog.warn('refill', `waiting for rewind @${seq} outcome threw`, error)
     return
@@ -502,7 +510,7 @@ interface RewindPortalsProps extends RewindBridgeDeps {
  * skipped when the target set is unchanged), so the plugin never runs a
  * synchronous full-transcript scan inside a commit microtask.
  */
-export function RewindPortals({ sessionId, sessionOf, chatOf, currentSessionId, t, subscribeLocale, setComposerText }: RewindPortalsProps): ReactNode {
+export function RewindPortals({ sessionId, sessionOf, chatOf, currentSessionId, watchChat, t, subscribeLocale, setComposerText }: RewindPortalsProps): ReactNode {
   const [targets, setTargets] = useState<readonly PortalTarget[]>([])
   // Rows we have hidden; re-shown when they leave the withdrawn span.
   const hidden = useRef(new WeakSet<HTMLElement>())
@@ -599,6 +607,7 @@ export function RewindPortals({ sessionId, sessionOf, chatOf, currentSessionId, 
           sessionId={sessionId}
           sessionOf={sessionOf}
           chatOf={chatOf}
+          watchChat={watchChat}
           setComposerText={setComposerText}
           t={t}
         />
@@ -610,6 +619,7 @@ export function RewindPortals({ sessionId, sessionOf, chatOf, currentSessionId, 
           sessionId={sessionId}
           sessionOf={sessionOf}
           chatOf={chatOf}
+          watchChat={watchChat}
           currentSessionId={currentSessionId}
           setComposerText={setComposerText}
           t={t}
@@ -625,13 +635,14 @@ interface RewindButtonProps {
   readonly sessionId: string
   readonly sessionOf: (sessionId: string) => SessionFace | undefined
   readonly chatOf: ChatOf
+  readonly watchChat: ChatWatch
   readonly currentSessionId: () => string | undefined
   readonly setComposerText: (sessionId: string, text: string) => boolean
   readonly t: Translate
 }
 
 /** The per-message ↶ button (28px, matching the harness IconActions). */
-function RewindButton({ target, sessionId, sessionOf, chatOf, currentSessionId, setComposerText, t }: RewindButtonProps): ReactNode {
+function RewindButton({ target, sessionId, sessionOf, chatOf, watchChat, currentSessionId, setComposerText, t }: RewindButtonProps): ReactNode {
   const onClick = (event: ReactMouseEvent<HTMLButtonElement>): void => {
     event.stopPropagation()
     const session = sessionOf(sessionId)
@@ -646,12 +657,13 @@ function RewindButton({ target, sessionId, sessionOf, chatOf, currentSessionId, 
     openPopover({
       session,
       chatOf,
+      watchChat,
       seq: node.seq,
       time: node.time,
       preview: messagePreviewOf(node),
       anchor: event.currentTarget,
       t,
-      onRewind: mode => { void runRewindAndFill(session, node.seq, mode, currentSessionId, chatOf, setComposerText) },
+      onRewind: mode => { void runRewindAndFill(session, node.seq, mode, currentSessionId, chatOf, watchChat, setComposerText) },
     })
   }
 
@@ -725,12 +737,13 @@ interface RetractButtonProps {
   readonly sessionOf: (sessionId: string) => SessionFace | undefined
   /** Passed through to openPopover (the shared PopoverOptions shape). */
   readonly chatOf: ChatOf
+  readonly watchChat: ChatWatch
   readonly setComposerText: (sessionId: string, text: string) => boolean
   readonly t: Translate
 }
 
 /** The per-pending-message ↶ button (same visual family as the durable button). */
-function RetractButton({ target, sessionId, sessionOf, chatOf, setComposerText, t }: RetractButtonProps): ReactNode {
+function RetractButton({ target, sessionId, sessionOf, chatOf, watchChat, setComposerText, t }: RetractButtonProps): ReactNode {
   const onClick = (event: ReactMouseEvent<HTMLButtonElement>): void => {
     event.stopPropagation()
     const session = sessionOf(sessionId)
@@ -738,6 +751,7 @@ function RetractButton({ target, sessionId, sessionOf, chatOf, setComposerText, 
     openPopover({
       session,
       chatOf,
+      watchChat,
       preview: target.preview,
       anchor: event.currentTarget,
       t,

--- a/tests/client-refill.test.ts
+++ b/tests/client-refill.test.ts
@@ -12,7 +12,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ChatConversationViewNode, CommandNode, SessionFace } from '@deepseek-ai/dsh-client-runtime/client'
 import { runRewindAndFill } from '../src/client/portals.tsx'
-import type { ChatOf, HiddenChat } from '../src/client/hidden.ts'
+import type { ChatOf, ChatWatch, HiddenChat } from '../src/client/hidden.ts'
 
 const TARGET = 5
 const COMMAND_SEQ = 99
@@ -62,7 +62,36 @@ function fakeSession() {
     getSnapshot: vi.fn(() => ({})),
   } as unknown as SessionFace
   const chatOf: ChatOf = () => chat
-  return { session, chatOf, command }
+  // First-check hit path: the watch is never needed (no-op), but the signature
+  // now requires it. See fakeSessionControlled for the watch-driven path.
+  const watch: ChatWatch = () => () => {}
+  return { session, chatOf, command, watch }
+}
+
+/**
+ * A fake session that does NOT append the executed rewind node inside
+ * `command`: the first check misses, and the refill only proceeds once the
+ * chat-update `watch` fires (alpha.1+ signal path). Exposes a manual trigger.
+ */
+function fakeSessionControlled() {
+  let chat = makeChat([userNode(TARGET)])
+  let trigger: (() => void) | null = null
+  const command = vi.fn(async () => ({ ok: true, value: { matched: true } }))
+  const watch: ChatWatch = (_sid, cb) => {
+    trigger = cb
+    return () => {}
+  }
+  const session = {
+    sessionId: 's1',
+    command,
+    subscribe: vi.fn(() => () => {}),
+    getSnapshot: vi.fn(() => ({})),
+  } as unknown as SessionFace
+  const chatOf: ChatOf = () => chat
+  const settleChat = (): void => {
+    chat = makeChat([userNode(TARGET), executedRewind(COMMAND_SEQ, TARGET)])
+  }
+  return { session, chatOf, command, watch, settleChat, getTrigger: (): (() => void) | null => trigger }
 }
 
 /** A `[data-composer-input]` contenteditable holding an existing draft. */
@@ -85,14 +114,14 @@ describe('runRewindAndFill (durable rewind refill)', () => {
   const currentSessionId = (): string => 's1'
 
   it('refills the empty composer (normal path emits no verbose diagnostics)', async () => {
-    const { session, chatOf, command } = fakeSession()
+    const { session, chatOf, command, watch } = fakeSession()
     const setComposerText = vi.fn(() => true)
     // The DEBUG switch no longer gates any call in this path: even with it
     // on, a successful rewind must not emit verbose info/debug output.
     localStorage.setItem('dsh-rewind.debug', 'dsh-rewind:refill,dsh-rewind:hiding')
     const info = vi.spyOn(console, 'info').mockReturnValue(undefined)
     const debug = vi.spyOn(console, 'debug').mockReturnValue(undefined)
-    await runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, setComposerText)
+    await runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, watch, setComposerText)
     expect(command).toHaveBeenCalledWith(`/rewind @${TARGET} both`)
     expect(setComposerText).toHaveBeenCalledTimes(1)
     expect(setComposerText).toHaveBeenCalledWith('s1', TEXT)
@@ -102,27 +131,55 @@ describe('runRewindAndFill (durable rewind refill)', () => {
 
   it('skips the refill when the composer already holds a draft (guard)', async () => {
     addEditableDraft('in progress draft')
-    const { session, chatOf } = fakeSession()
+    const { session, chatOf, watch } = fakeSession()
     const setComposerText = vi.fn(() => true)
-    await runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, setComposerText)
+    await runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, watch, setComposerText)
     expect(setComposerText).not.toHaveBeenCalled()
   })
 
   it('turns a session.command throw into a warn instead of an unhandled rejection', async () => {
-    const { session, chatOf } = fakeSession()
+    const { session, chatOf, watch } = fakeSession()
     session.command = vi.fn(async () => { throw new Error('teardown') }) as SessionFace['command']
     const setComposerText = vi.fn(() => true)
     const warn = vi.spyOn(console, 'warn').mockReturnValue(undefined)
-    await expect(runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, setComposerText)).resolves.toBeUndefined()
+    await expect(runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, watch, setComposerText)).resolves.toBeUndefined()
     expect(setComposerText).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalledTimes(1)
   })
 
   it('does nothing on an unmatched rewind (matched !== true)', async () => {
-    const { session, chatOf } = fakeSession()
+    const { session, chatOf, watch } = fakeSession()
     session.command = vi.fn(async () => ({ ok: true, value: { matched: false } })) as SessionFace['command']
     const setComposerText = vi.fn(() => true)
-    await runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, setComposerText)
+    await runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, watch, setComposerText)
+    expect(setComposerText).not.toHaveBeenCalled()
+  })
+
+  it('refills after the chat-update watch fires (alpha signal path: the first check misses)', async () => {
+    const { session, chatOf, command, watch, settleChat, getTrigger } = fakeSessionControlled()
+    const setComposerText = vi.fn(() => true)
+    const call = runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, watch, setComposerText)
+    // command resolves (matched) and the first check misses; the refill waits on watch
+    await Promise.resolve()
+    await Promise.resolve()
+    settleChat()
+    getTrigger()?.()
+    await call
+    expect(command).toHaveBeenCalledWith(`/rewind @${TARGET} both`)
+    expect(setComposerText).toHaveBeenCalledTimes(1)
+    expect(setComposerText).toHaveBeenCalledWith('s1', TEXT)
+  })
+
+  it('still honours the empty-composer guard when the watch fires late', async () => {
+    addEditableDraft('in progress draft')
+    const { session, chatOf, watch, settleChat, getTrigger } = fakeSessionControlled()
+    const setComposerText = vi.fn(() => true)
+    const call = runRewindAndFill(session, TARGET, 'both', currentSessionId, chatOf, watch, setComposerText)
+    await Promise.resolve()
+    await Promise.resolve()
+    settleChat()
+    getTrigger()?.()
+    await call
     expect(setComposerText).not.toHaveBeenCalled()
   })
 })

--- a/tests/client-wait.test.ts
+++ b/tests/client-wait.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * `waitForCommand` wait-signal probes (SiriLee/dsh-rewind#14): a waiting caller
+ * must be woken when the CHAT snapshot changes, not only by the session
+ * face's `subscribe`. On alpha.1+ the chat moved off the session face into the
+ * `uiConversation` view, so the face no longer fires on a chat update; the fix
+ * lets a caller pass a `watch` bound to that view. These tests lock the four
+ * behaviors: first-check hit, watch-triggered hit (the alpha signal path), the
+ * default session face fallback (rc.2), and timeout.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ChatConversationViewNode, CommandNode, SessionFace } from '@deepseek-ai/dsh-client-runtime/client'
+import { waitForCommand } from '../src/client/popover.ts'
+import { isExecutedRewindCommand, type ChatOf, type HiddenChat } from '../src/client/hidden.ts'
+
+const TARGET = 5
+const COMMAND_SEQ = 99
+const OUTCOME_TEXT = 'Withdrawn seq 5 and everything after it.'
+
+function node(key: string, kind: string, anchorSeq: number, data: unknown): ChatConversationViewNode {
+  return { key, kind, id: key, target: 'chat', anchorSeq, data } as unknown as ChatConversationViewNode
+}
+
+function userNode(seq: number): ChatConversationViewNode {
+  return node(`u${seq}`, 'user', seq, { seq, content: [{ type: 'text', text: 'hello world' }] })
+}
+
+function executedRewind(seq: number, target: number): ChatConversationViewNode {
+  const data = {
+    kind: 'command', seq, time: 0, commandId: 'cid', name: 'rewind',
+    args: `@${target} both`,
+    outcome: { kind: 'success', text: OUTCOME_TEXT, sourceEventSeq: seq },
+  } as unknown as CommandNode
+  return node(`c${seq}`, 'command', seq, data)
+}
+
+function makeChat(nodes: readonly ChatConversationViewNode[]): HiddenChat {
+  const order: string[] = []
+  const map = new Map<string, ChatConversationViewNode>()
+  for (const n of nodes) {
+    order.push(n.key)
+    map.set(n.key, n)
+  }
+  return { order, nodes: { get: (k: string) => map.get(k) } } as HiddenChat
+}
+
+/** A fake session + chat variable with a live-outcome roll-in helper. */
+function makeFake() {
+  let chat = makeChat([userNode(TARGET)])
+  let subscribeCb: (() => void) | null = null
+  const session = {
+    sessionId: 's1',
+    subscribe: vi.fn((cb: () => void) => { subscribeCb = cb; return () => {} }),
+  } as unknown as SessionFace
+  const chatOf: ChatOf = () => chat
+  const settleChatWithOutcome = (): void => {
+    chat = makeChat([userNode(TARGET), executedRewind(COMMAND_SEQ, TARGET)])
+  }
+  return { session, chatOf, settleChatWithOutcome, getSubscribeCb: (): (() => void) | null => subscribeCb }
+}
+
+const matchExecuted = (node: CommandNode): boolean => isExecutedRewindCommand(node, TARGET)
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('waitForCommand wait signal', () => {
+  it('resolves immediately when the first check finds an outcome (no watch needed)', async () => {
+    const { session, chatOf, settleChatWithOutcome } = makeFake()
+    settleChatWithOutcome()
+    const outcome = await waitForCommand(session, chatOf, matchExecuted, 8000)
+    expect(outcome).toEqual({ kind: 'success', text: OUTCOME_TEXT })
+  })
+
+  it('is woken by the passed watch when the first check misses (alpha chat-update signal)', async () => {
+    const { session, chatOf, settleChatWithOutcome } = makeFake()
+    const callbacks: Array<() => void> = []
+    const watch = (cb: () => void): (() => void) => {
+      callbacks.push(cb)
+      return () => {}
+    }
+    // First check runs synchronously but finds no outcome yet -> waits on watch.
+    const pending = waitForCommand(session, chatOf, matchExecuted, 8000, watch)
+    expect(callbacks).toHaveLength(1)
+    // The chat snapshot updates (as on alpha.1+), then the watch fires.
+    settleChatWithOutcome()
+    for (const cb of callbacks) cb()
+    await expect(pending).resolves.toEqual({ kind: 'success', text: OUTCOME_TEXT })
+  })
+
+  it('falls back to the session face subscribe when no watch is passed (rc.2 signal)', async () => {
+    const { session, chatOf, settleChatWithOutcome, getSubscribeCb } = makeFake()
+    const pending = waitForCommand(session, chatOf, matchExecuted, 8000)
+    expect(session.subscribe).toHaveBeenCalledTimes(1)
+    // The session-face subscription is the wait signal: fire its callback after
+    // the chat rolls in, mirroring rc.2 where a chat update invalidates the face.
+    settleChatWithOutcome()
+    getSubscribeCb()?.()
+    await expect(pending).resolves.toEqual({ kind: 'success', text: OUTCOME_TEXT })
+  })
+
+  it('resolves null on timeout when nothing ever signals', async () => {
+    vi.useFakeTimers()
+    const { session, chatOf } = makeFake()
+    const pending = waitForCommand(session, chatOf, matchExecuted, 5000)
+    await vi.advanceTimersByTimeAsync(5000)
+    await expect(pending).resolves.toBeNull()
+  })
+})

--- a/tests/client-wait.test.ts
+++ b/tests/client-wait.test.ts
@@ -12,7 +12,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ChatConversationViewNode, CommandNode, SessionFace } from '@deepseek-ai/dsh-client-runtime/client'
 import { waitForCommand } from '../src/client/popover.ts'
-import { isExecutedRewindCommand, type ChatOf, type HiddenChat } from '../src/client/hidden.ts'
+import { isExecutedRewindCommand, resolveChatWatch, type ChatOf, type HiddenChat } from '../src/client/hidden.ts'
 
 const TARGET = 5
 const COMMAND_SEQ = 99
@@ -108,5 +108,36 @@ describe('waitForCommand wait signal', () => {
     const pending = waitForCommand(session, chatOf, matchExecuted, 5000)
     await vi.advanceTimersByTimeAsync(5000)
     await expect(pending).resolves.toBeNull()
+  })
+})
+
+describe('resolveChatWatch channel selection', () => {
+  const viewOf = (subscribe?: (cb: () => void) => () => void) => ({ subscribe })
+  const faceOf = (subscribe: (cb: () => void) => () => void) => ({ subscribe })
+
+  it('prefers the uiConversation view subscribe when it is reachable', () => {
+    const viewSub = vi.fn(() => () => {})
+    const faceSub = vi.fn(() => () => {})
+    resolveChatWatch(() => viewOf(viewSub), () => faceOf(faceSub), 's1', () => {})
+    expect(viewSub).toHaveBeenCalledTimes(1)
+    expect(faceSub).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the session face when the view has no subscribe', () => {
+    const faceSub = vi.fn(() => () => {})
+    resolveChatWatch(() => viewOf(undefined), () => faceOf(faceSub), 's1', () => {})
+    expect(faceSub).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the session face when the view is unreachable', () => {
+    const faceSub = vi.fn(() => () => {})
+    resolveChatWatch(() => undefined, () => faceOf(faceSub), 's1', () => {})
+    expect(faceSub).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns a no-op when neither the view nor the face is available', () => {
+    const unsub = resolveChatWatch(() => undefined, () => undefined, 's1', () => {})
+    expect(typeof unsub).toBe('function')
+    expect(() => unsub()).not.toThrow()
   })
 })


### PR DESCRIPTION
# Wait for the alpha chat-view update signal in `waitForCommand`

## Summary

On harness `0.1.2-alpha.*`, after a rewind the withdrawn message text was
sometimes not refilled into the composer until the user switched sessions or
sent something else. This PR fixes that timing race on the **alpha** channel
only; the rc.2 **behavior** is preserved — its wait still resolves via
`session.subscribe`, and the change is confined to `src/client/**`.

## Root cause

`waitForCommand` waited on the session face's `session.subscribe` to learn that
an executed rewind's command node had settled. On alpha.1+ the chat snapshot
moved off the session face into the `uiConversation` "chat" view, and the face's
`subscribe` no longer fires on a chat update. So when `waitForCommand`'s first
check missed (the outcome not yet in the chat) and the session was idle (no
queue/first-turn/running change), nothing ever woke it and the refill timed out.
rc.2 was unaffected (its face snapshot still carries the chat, so
`session.subscribe` there still reflects a chat update).

## Fix (plan A)

Add an optional `watch` signal to `waitForCommand`, and thread a `watchChat`
deps through the refill / preview / candidate-list waits:

- `watchChat` subscribes to the `uiConversation` "chat" view's `subscribe` on
  alpha.1+, and falls back to the session face `subscribe` when the view is
  unreachable (rc.2, or before it registers). The wait signal stays
  **event-driven** (no polling); the channel-selection step is the pure
  `resolveChatWatch` function.
- Without a `watch`, `waitForCommand` keeps using `session.subscribe`, so the
  rc.2 path is unchanged.
- A failed/session-less watch degrades to the session face subscribe or a no-op;
  the first synchronous check and the bounded timeout are preserved.

## Tests

- `tests/client-wait.test.ts` — new: first-check hit, watch-triggered hit (the
  alpha signal path), the session-face fallback (rc.2), and timeout; plus
  `resolveChatWatch` channel selection (view-preferred when reachable,
  session-face fallback when the view is unavailable, no-op when neither exists).
- `tests/client-refill.test.ts` — extended with the watch-driven path
  (first check misses → watch fires → refill) and the empty-composer guard
  still honoured when the watch fires late.

## Validation

- `npm run check` is green (typecheck, 354 tests, build, verify:host, pack).
- Manual real-engine verification passed on **rc.2** and **alpha.5** (WebKit).
- The change is entirely in `src/client/**`; the host (`lib/index.js`) and the
  on-disk format are untouched.

Fixes #14 (analysis in github discussion #11).
