### PR TITLE
test: preserve parent traversal in cwd fixture

### DIFF
--- a/tests/session-cwd.test.ts
+++ b/tests/session-cwd.test.ts
@@ -12,7 +12,7 @@ import { execSessionCwd, sessionCwd } from '../src/session-cwd.ts'
 
 /** A real existing directory (canonicalPath realpaths it) with a `..` alias. */
 const BASE = join(tmpdir(), 'dsh-rewind-session-cwd-test')
-const ALIAS = join(BASE, '..', basename(BASE))
+const ALIAS = `${BASE}/../${basename(BASE)}`
 mkdirSync(BASE, { recursive: true })
 
 describe('sessionCwd', () => {
@@ -30,7 +30,7 @@ describe('sessionCwd', () => {
   })
 
   it('canonicalizes a cwd that itself contains parent traversal', () => {
-    expect(sessionCwd(ALIAS, 'a.ts')).toBe(realpathSync(BASE))
+    expect(sessionCwd(ALIAS, 'a.ts')).toBe(realpathSync.native(ALIAS))
   })
 
   it('keeps absolute requested paths untouched (cwd irrelevant)', () => {


### PR DESCRIPTION
## Summary

- construct the test alias without `path.join`, which lexically removes `..`
- compare against the same native realpath semantics used by `canonicalPath`

## Validation

- `npm run check`
- 24 test files / 339 tests passed on macOS arm64, Node 24.13.0
